### PR TITLE
Improve scopes for Post and PostsController

### DIFF
--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -5,12 +5,12 @@ module App
     # GET /
     # GET /posts
     def popular
-      @posts = Post.popular.page(params[:page])
+      @posts = Post.popular.page(params[:page]).includes(:user).limit(10)
     end
 
     # GET /posts/newest
     def newest
-      @posts = Post.newest.page(params[:page])
+      @posts = Post.newest.page(params[:page]).includes(:user).limit(10)
     end
 
     # GET /posts/new

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,6 +18,6 @@ class Post < ActiveRecord::Base
   validates_with PostValidator
 
   # Scopes
-  scope :newest, lambda { |count=10| order('created_at DESC').limit(count) }
-  scope :popular, lambda { |count=10| select('*, (comments_count + like_emotions_count) AS score').order('score DESC').limit(count) }
+  scope :newest, lambda { order('created_at DESC') }
+  scope :popular, lambda { select('*, (comments_count + like_emotions_count) AS score').order('score DESC') }
 end


### PR DESCRIPTION
Je ne suis pas fan de mettre `limit(<x>)` dans un scope qui retourne des posts selon un ordre. Le scope `newest` n’est pas lié avec le nombre de posts qu’on veut dans la requête SQL. Je pense qu’on doit tirer avantage du fait que les scopes d’ActiveRecord sont chainables.

Bonus: _eager-loading_ de `Post#user`.
