### PR TITLE
Add basic popular sorting function implemented in mysql

### DIFF
--- a/app/models/concerns/post_popular_sorting.rb
+++ b/app/models/concerns/post_popular_sorting.rb
@@ -1,0 +1,17 @@
+module PostPopularSorting
+  extend ActiveSupport::Concern
+
+  included do
+    scope :popular, -> do
+      limit_updated_at = Time.now - 2.month
+      rank_select = "
+        posts.*,
+        round(((posts.comments_count + 3*posts.like_emotions_count)
+        /power(((unix_timestamp(utc_timestamp())-unix_timestamp(posts.created_at))/200),0.7)
+        ), 8) as rank
+      ".gsub(/\s+/, " ").strip
+
+      select(rank_select).where('updated_at >= ?', limit_updated_at).order('rank DESC')
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ActiveRecord::Base
   include ExternalMetadata
+  include PostPopularSorting
 
   # Use Parole
   acts_as_commentable
@@ -21,5 +22,4 @@ class Post < ActiveRecord::Base
 
   # Scopes
   scope :newest, lambda { order('created_at DESC') }
-  scope :popular, lambda { select('*, (comments_count + like_emotions_count) AS score').order('score DESC') }
 end


### PR DESCRIPTION
Petit benchmark:

Pour un dataset de 30 000 posts, sorter prend ~60ms.

C'est implémenté avec des fonctions MySQL mais ce sera pas dur de traduire en Postgresql quand on décidera de changer pour Heroku.
