### PR TITLE
Fix validations for fresh_url

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,7 +16,8 @@ class Post < ActiveRecord::Base
   belongs_to :user
 
   # Validations
-  validates :url, http: true, fresh_url: true
+  validates :url, http: true
+  validates :url, fresh_url: true, on: :create
   validates :title, presence: true
   validates_with PostValidator
 


### PR DESCRIPTION
La validation pour un `fresh_url` doit se faire seulement à la création d'un Post et non lors d'un save.
