### PR TITLE
Retourner un 403 lors d'un double up vote

### DIFF
--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -38,14 +38,7 @@ module App
 
     # POST /posts/:id/like
     def like
-      if current_user.express!(:like, @post).newly_expressed?
-        # Should definitively be located in a callback
-        # but since Emotions don't provide them for now,
-        # it's here.
-        # https://github.com/mirego/emotions/pull/8
-        @post.user.increment!(:karma)
-      end
-
+      current_user.like_post!(@post)
       redirect_to :back
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,17 @@ class User < ActiveRecord::Base
   def to_param
     username
   end
+
+  def like_post!(post)
+    self.class.transaction do
+      # Should definitively be located in a callback
+      # but since Emotions don't provide them for now,
+      # it's here.
+      # https://github.com/mirego/emotions/pull/8
+      raise DoubleLikeError unless express!(:like, post).newly_expressed?
+      post.user.increment!(:karma)
+    end
+  end
+
+  class DoubleLikeError < StandardError; end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,7 @@ module Ocnews
     if Rails.configuration.domain
       config.middleware.use Rack::CanonicalHost, Rails.configuration.domain
     end
+
+    config.action_dispatch.rescue_responses.merge! 'User::DoubleLikeError' => :forbidden
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,4 +13,32 @@ describe User do
       specify { should_not be_valid }
     end
   end
+
+  describe "#like_post!" do
+    let(:liker)  { create(:user) }
+    let(:author) { create(:user, karma: 0) }
+    let(:post)   { create(:url_post, user: author) }
+
+    context "with blank post" do
+      before { liker.like_post!(post) }
+
+      it "expresses like emotion" do
+        expect(liker.like_about?(post)).to be_true
+      end
+
+      it "increments author's karma" do
+        expect(author.karma).to eq(1)
+      end
+    end
+
+    context "when user already liked post" do
+      let(:post) do
+        create(:url_post, user: author).tap { |post| liker.like_post!(post) }
+      end
+
+      it "raises User::DoubleLikeError" do
+        expect { liker.like_post!(post) }.to raise_error(User::DoubleLikeError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Valider lors d'un up vote que le user n'a pas déjà voté. Si c'est le cas, retourner un 403.
