### PR TITLE
Add ensure_current_user filter

### DIFF
--- a/app/controllers/app/application_controller.rb
+++ b/app/controllers/app/application_controller.rb
@@ -2,4 +2,10 @@ class App::ApplicationController < ::ApplicationController
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+protected
+
+  def ensure_current_user
+    redirect_to :back, alert: t('.not_signed_in') unless current_user
+  end
 end

--- a/app/controllers/app/comments_controller.rb
+++ b/app/controllers/app/comments_controller.rb
@@ -1,12 +1,9 @@
 class App::CommentsController < App::ApplicationController
+  before_action :ensure_current_user, only: [:create, :like]
   before_action :fetch_comment, only: [:show, :like]
 
   # POST /comments/new
   def create
-    unless current_user
-      return redirect_to :back, alert: t('.not_signed_in')
-    end
-
     @comment = current_user.comments.build
     @comment.assign_attributes(comment_params)
 

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -1,4 +1,5 @@
 class App::PostsController < App::ApplicationController
+  before_action :ensure_current_user, only: [:create, :like, :new]
   before_action :fetch_post, only: [:show, :like]
 
   # GET /
@@ -21,7 +22,6 @@ class App::PostsController < App::ApplicationController
   def create
     @post = current_user.posts.build
     @post.assign_attributes(post_params)
-
 
     if @post.save
       current_user.like_post!(@post)


### PR DESCRIPTION
Au lieu de vérifier manuellement dans chaque action si l’utilisateur est connecté, on fait ça dans un filtre `before_action`.
