### PR TITLE
Make available 2 rss feeds for newest and popular posts

### DIFF
--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -6,11 +6,25 @@ class App::PostsController < App::ApplicationController
   # GET /posts
   def popular
     @posts = Post.popular.page(params[:page]).includes(:user)
+
+    respond_to do |format|
+      format.html
+
+      # /posts/popular.rss
+      format.rss { render :layout => false }
+    end
   end
 
   # GET /posts/newest
   def newest
     @posts = Post.newest.page(params[:page]).includes(:user)
+
+    respond_to do |format|
+      format.html
+
+      # /posts/newest.rss
+      format.rss { render :layout => false }
+    end
   end
 
   # GET /posts/new

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -11,7 +11,7 @@ class App::PostsController < App::ApplicationController
       format.html
 
       # /posts/popular.rss
-      format.rss { render :layout => false }
+      format.rss{ render layout: false }
     end
   end
 
@@ -23,7 +23,7 @@ class App::PostsController < App::ApplicationController
       format.html
 
       # /posts/newest.rss
-      format.rss { render :layout => false }
+      format.rss{ render layout: false }
     end
   end
 

--- a/app/views/app/posts/newest.rss.builder
+++ b/app/views/app/posts/newest.rss.builder
@@ -1,0 +1,17 @@
+xml.instruct! :xml, :version => "1.0" 
+xml.rss :version => "2.0" do
+  xml.channel do
+    xml.title  "OCN Récent"
+    xml.description "OCN Récent"
+    xml.link newest_app_posts_url
+
+    for post in @posts
+      xml.item do
+        xml.title post.title
+        xml.pubDate post.created_at.to_s(:rfc822)
+        xml.link app_post_url(post)
+        xml.guid app_post_url(post)
+      end
+    end
+  end
+end

--- a/app/views/app/posts/popular.rss.builder
+++ b/app/views/app/posts/popular.rss.builder
@@ -1,0 +1,17 @@
+xml.instruct! :xml, :version => "1.0" 
+xml.rss :version => "2.0" do
+  xml.channel do
+    xml.title  "OCN Populaire"
+    xml.description "OCN Populaire"
+    xml.link popular_app_posts_url
+
+    for post in @posts
+      xml.item do
+        xml.title post.title
+        xml.pubDate post.created_at.to_s(:rfc822)
+        xml.link app_post_url(post)
+        xml.guid app_post_url(post)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <%= javascript_include_tag 'application' %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= csrf_meta_tags %>
+    <%= auto_discovery_link_tag(:rss, app_rss_url) %>
+    <%= auto_discovery_link_tag(:rss, newest_app_posts_url(:format => :rss)) %>
+    <%= auto_discovery_link_tag(:rss, popular_app_posts_url(:format => :rss)) %>
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.css" rel="stylesheet">
   </head>
   <body class="nav-close">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
     <%= favicon_link_tag 'favicon.ico' %>
     <%= csrf_meta_tags %>
     <%= auto_discovery_link_tag(:rss, app_rss_url) %>
-    <%= auto_discovery_link_tag(:rss, newest_app_posts_url(:format => :rss)) %>
-    <%= auto_discovery_link_tag(:rss, popular_app_posts_url(:format => :rss)) %>
+    <%= auto_discovery_link_tag(:rss, newest_app_posts_url(format: :rss)) %>
+    <%= auto_discovery_link_tag(:rss, popular_app_posts_url(format: :rss)) %>
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.css" rel="stylesheet">
   </head>
   <body class="nav-close">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Ocnews::Application.routes.draw do
   namespace :app, path: '' do
 
     # /rss will always show recent posts (using /posts/newest?format=rss)
-    get 'rss', :to => 'posts#newest', :defaults => { :format => :rss }
+    get 'rss', to: 'posts#newest', defaults: { format: :rss }
 
     resources :posts, only: [:show, :new, :create] do
       get 'newest', on: :collection, as: 'newest'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,13 @@ Ocnews::Application.routes.draw do
   root 'app/posts#popular'
 
   namespace :app, path: '' do
+
+    # /rss will always show recent posts (using /posts/newest?format=rss)
+    get 'rss', :to => 'posts#newest', :defaults => { :format => :rss }
+
     resources :posts, only: [:show, :new, :create] do
       get 'newest', on: :collection, as: 'newest'
+      get 'popular', on: :collection, as: 'popular'
       post 'like', on: :member, as: 'like'
     end
 


### PR DESCRIPTION
Je n'ai pas ajouté de lien à visible l'interface, mais simplement inclus dans le head du app layout ceci:

<link href="http://ocn.localhost.com:3000/rss" rel="alternate" title="RSS" type="application/rss+xml" />
<link href="http://ocn.localhost.com:3000/posts/newest.rss" rel="alternate" title="RSS" type="application/rss+xml" />
<link href="http://ocn.localhost.com:3000/posts/popular.rss" rel="alternate" title="RSS" type="application/rss+xml" />

J'ai fait en sorte que si quelqu'un accède à "ocn.opencode.ca/rss" que par défaut ce soit le feed rss "récents" qui s'affiche, soit la même chose que "ocn.opencode.ca/posts/newest.rss".

Le lien donné pour chaque post dans le feed rss pointe sur la ressource sur ocn.opencode.ca/posts/<pretty-url-du-post>, car ainsi on tombe dans la discussion du post et on peut voir les commentaires, ou sinon alors la personne une fois rendu dans le post pourra tout simplement suivre le lien pour tomber sur la page linké si cest le cas pour ce post-ci (line externe je parle). À la base les gens entre sur ocn.opencode.ca.

Les titres des feed seront p-e à revoir éventuellement, jai hardcodé pour l'instant, sinon ce serait cool d'utiliser de quoi de configurable pour les titres de pages, later.

À faire évoluer! ;)
