### PR TITLE
Remove comment form when not logged in

### DIFF
--- a/app/views/app/comments/_form.html.erb
+++ b/app/views/app/comments/_form.html.erb
@@ -1,14 +1,16 @@
-<div role="form" class="comment-form" <%= ' hidden' if comment.commentable_type == 'Comment' %>>
-  <%= form_for comment, url: app_comments_path do |f| %>
-    <%= render_error_messages(f.object) %>
-    <%= f.hidden_field :commentable_id %>
-    <%= f.hidden_field :commentable_type %>
-    <div class="form-group">
-      <%= f.label :comment, :class => "control-label" %>
-      <%= f.text_area :comment, :class => "form-control" %>
-    </div>
-    <div class="form-group">
-      <%= submit_tag nil, :class => "btn btn-primary"%>
-    </div>
-  <% end %>
-</div>
+<% if user_signed_in? %>
+  <div role="form" class="comment-form" <%= ' hidden' if comment.commentable_type == 'Comment' %>>
+    <%= form_for comment, url: app_comments_path do |f| %>
+      <%= render_error_messages(f.object) %>
+      <%= f.hidden_field :commentable_id %>
+      <%= f.hidden_field :commentable_type %>
+      <div class="form-group">
+        <%= f.label :comment, :class => "control-label" %>
+        <%= f.text_area :comment, :class => "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= submit_tag nil, :class => "btn btn-primary"%>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/app/comments/_mini.html.erb
+++ b/app/views/app/comments/_mini.html.erb
@@ -8,15 +8,20 @@
       , il y a
       <%= link_to time_ago_in_words(comment.created_at), app_comment_path(comment) %>
       (<%= comment.points_count %>)
-      <a href="javascript://" class="reply">reply</a>
+
+      <% if user_signed_in? %>
+        <a href="javascript://" class="reply">reply</a>
+      <% end %>
     </div>
     <div class="body">
       <%= comment.formatted_comment %>
     </div>
 
-    <div class="comment-box">
-      <%= render partial: 'app/comments/form', locals: { comment: comment.comments.build } %>
-    <div>
+    <% if user_signed_in? %>
+      <div class="comment-box">
+        <%= render partial: 'app/comments/form', locals: { comment: comment.comments.build } %>
+      <div>
+    <% end %>
 
     <% threaded && comment.with_comments do %>
       <ul>


### PR DESCRIPTION
Très simple, on enlève la boîte de commentaire lorsque l'utilisateur n'est pas connecté. Fixes #112 
